### PR TITLE
use `=` to test equalities of two strings instead of `==`

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -14,7 +14,7 @@ BASE_DIR=.
 DATA_DIR=${BASE_DIR}/drop_dataset
 CODE_DIR=${BASE_DIR}
 
-if [ ${TMSPAN} == tag_mspan ];then
+if [ ${TMSPAN} = tag_mspan ]; then
   echo "Use tag_mspan model..."
   CACHED_TRAIN=${DATA_DIR}/tmspan_cached_roberta_train.pkl
   CACHED_DEV=${DATA_DIR}/tmspan_cached_roberta_dev.pkl


### PR DESCRIPTION
`[ ${TMSPAN} == tag_mspan ]` -> `[ ${TMSPAN} = tag_mspan ]`

There may be a bug. (see https://man.linuxde.net/test)